### PR TITLE
Added missing Void Cascade option on Fissure Alerts

### DIFF
--- a/src/components/settings/FissureAlerts.svelte
+++ b/src/components/settings/FissureAlerts.svelte
@@ -11,6 +11,7 @@
     "Survival",
     "Defense",
     "Interception",
+    "Void Cascade",
     "Mobile Defense",
     "Capture",
     "Exterminate",


### PR DESCRIPTION
## What & why

Added the missing Void Cascade Option in the Fissure alerts

Code was already prepared for Void Cascade alerts, only the dropdown was affected because of that:
<img width="559" height="532" alt="image" src="https://github.com/user-attachments/assets/49096f5a-1064-4be3-ba3f-12538e76f005" />

Evidence:
<img width="451" height="233" alt="image" src="https://github.com/user-attachments/assets/40df0d54-4dc8-4cc5-afbc-41f2a7d64c71" />

Builds:
typecheck/lint/format:check:
<img width="1117" height="347" alt="image" src="https://github.com/user-attachments/assets/c5ab98c6-c43e-4d26-9ee9-50b7966c1b6d" />

test:
<img width="720" height="128" alt="image" src="https://github.com/user-attachments/assets/c16369cb-7cc2-4088-bb21-c8868555676a" />

build:
<img width="1119" height="647" alt="image" src="https://github.com/user-attachments/assets/4e0583d4-60cd-4964-b248-f7a0754cfef1" />


## Checklist

- [ ] `pnpm run check`, `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check` and `pnpm test` pass
- [ ] Production build works (`pnpm run build`)
- [ ] Follows the conventions in `CONTRIBUTING.md`
- [ ] No telemetry or crash reporting added
