### PR TITLE
Fix dynamic fissure alert mission types

### DIFF
--- a/services/worldStateParser.ts
+++ b/services/worldStateParser.ts
@@ -360,22 +360,11 @@ function formatNodeLabel(nodeId: string): string {
 }
 
 function formatMissionTypeLabel(missionType: string, nodeId: string): string {
-  if (MISSION_TYPE[missionType]) {
-    return MISSION_TYPE[missionType];
-  }
-  const region = REGION_TRANSLATION.regions[nodeId];
-  const missionName = resolveDictValue(region?.missionName);
-  if (missionName) {
-    return missionName;
-  }
-  if (typeof missionType === "string" && missionType.startsWith("MT_")) {
-    return missionType
-      .replace(/^MT_/, "")
-      .toLowerCase()
-      .replace(/(^|\s|_)\w/g, (c) => c.toUpperCase())
-      .replace(/_/g, " ");
-  }
-  return missionType || "Unknown";
+  const fromExport = resolveDictValue(getMissionTypeLookup()[missionType]?.name);
+  if (fromExport) return titleCase(fromExport);
+  const fromNode = resolveDictValue(REGION_TRANSLATION.regions[nodeId]?.missionName);
+  if (fromNode) return titleCase(fromNode);
+  return MISSION_TYPE[missionType] || enumTailLabel(missionType, "MT_");
 }
 
 // Void storms omit MissionType, so resolve the node mission and normalize its dict label.

--- a/src/components/settings/FissureAlerts.svelte
+++ b/src/components/settings/FissureAlerts.svelte
@@ -2,28 +2,13 @@
   import { overlaySettings, applyOverlaySettingsResponse } from "../../stores/overlaySettings.js";
   import { invoke } from "../../lib/ipc.js";
   import { tr, type MessageKey, type Translator } from "../../lib/i18n.js";
+  import { fissureMissionTypeOptions } from "../../lib/world/useWorldView.js";
+  import { worldData } from "../../stores/world.js";
   import type { FissureAlert } from "../../types/ipc.js";
   import ThemedButton from "../ThemedButton.svelte";
   import ThemedSelect from "../ThemedSelect.svelte";
 
   const TIERS = ["any", "Lith", "Meso", "Neo", "Axi", "Requiem", "Omnia"] as const;
-  const MISSION_TYPES = [
-    "any",
-    "Survival",
-    "Defense",
-    "Interception",
-    "Void Cascade",
-    "Mobile Defense",
-    "Capture",
-    "Exterminate",
-    "Spy",
-    "Excavation",
-    "Rescue",
-    "Sabotage",
-    "Disruption",
-    "Defection",
-    "Assassination",
-  ] as const;
   const STEEL_PATH_OPTIONS: ReadonlyArray<{
     value: "any" | "normal" | "steel";
     labelKey: MessageKey;
@@ -64,6 +49,7 @@
   let error = "";
 
   $: alerts = ($overlaySettings.fissureAlerts ?? []) as FissureAlert[];
+  $: missionTypes = fissureMissionTypeOptions($worldData?.fissures);
 
   async function persistAlerts(updated: FissureAlert[]): Promise<void> {
     saving = true;
@@ -153,8 +139,9 @@
       {/each}
     </ThemedSelect>
     <ThemedSelect bind:value={newMissionType} disabled={saving}>
-      {#each MISSION_TYPES as m}
-        <option value={m}>{m === "any" ? $tr("settings.fissureAnyMission") : m}</option>
+      <option value="any">{$tr("settings.fissureAnyMission")}</option>
+      {#each missionTypes as m}
+        <option value={m}>{m}</option>
       {/each}
     </ThemedSelect>
     <ThemedSelect bind:value={newSteelPath} disabled={saving}>

--- a/src/lib/world/useWorldView.ts
+++ b/src/lib/world/useWorldView.ts
@@ -235,6 +235,12 @@ function fissureSourceMode(f: Fissure): Exclude<FissureMode, "all"> {
   return f.isHard === true ? "steel" : "normal";
 }
 
+export function fissureMissionTypeOptions(fissures: Fissure[] | undefined): string[] {
+  return [
+    ...new Set((fissures || []).map((f) => f.missionType?.trim()).filter(Boolean) as string[]),
+  ].sort((a, b) => a.localeCompare(b));
+}
+
 export function buildFissureRows(
   fissures: Fissure[] | undefined,
   mode: FissureMode,

--- a/tests/main/worldStateParser.test.ts
+++ b/tests/main/worldStateParser.test.ts
@@ -1,5 +1,6 @@
 ﻿import { describe, expect, it } from "vitest";
 
+import { setGameLocale } from "../../services/gameLocale";
 import * as parser from "../../services/worldStateParser";
 
 // parseRaw returns Record<string, unknown>; shape only what these tests read.
@@ -111,6 +112,59 @@ describe("worldStateParser.parseRaw", () => {
     expect(parsed.voidTrader?.location).toBe("Larunda Relay (Earth)");
     expect(parsed.vaultTrader?.location).toBe("Strata Relay (Mars)");
     expect(parsed.sortie?.expiry).toBeTruthy();
+  });
+
+  it("uses the Warframe mission data labels for fissures in title case", () => {
+    const now = Date.now();
+    const parsed = parseRaw({
+      ActiveMissions: [
+        {
+          Modifier: "VoidT1",
+          MissionType: "MT_CORRUPTION",
+          Node: "SolNode230",
+          Expiry: dateLong(now + 60_000),
+        },
+        {
+          Modifier: "VoidT2",
+          MissionType: "MT_PURIFY",
+          Node: "SolNode167",
+          Expiry: dateLong(now + 60_000),
+        },
+        {
+          Modifier: "VoidT3",
+          MissionType: "MT_ASSAULT",
+          Node: "SolNode741",
+          Expiry: dateLong(now + 60_000),
+        },
+      ],
+    });
+
+    expect(parsed.fissures.map((f) => f.missionType)).toEqual([
+      "Void Flood",
+      "Infested Salvage",
+      "Assault",
+    ]);
+  });
+
+  it("keeps fissure mission labels stable when the game locale changes", () => {
+    const now = Date.now();
+    setGameLocale("de");
+    try {
+      const parsed = parseRaw({
+        ActiveMissions: [
+          {
+            Modifier: "VoidT1",
+            MissionType: "MT_CORRUPTION",
+            Node: "SolNode230",
+            Expiry: dateLong(now + 60_000),
+          },
+        ],
+      });
+
+      expect(parsed.fissures[0].missionType).toBe("Void Flood");
+    } finally {
+      setGameLocale("en");
+    }
   });
 
   it("derives the real mission type for railjack void storms", () => {

--- a/tests/renderer/lib/useWorldView.test.ts
+++ b/tests/renderer/lib/useWorldView.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildFissureRows } from "../../../src/lib/world/useWorldView.js";
+import {
+  buildFissureRows,
+  fissureMissionTypeOptions,
+} from "../../../src/lib/world/useWorldView.js";
 import type { Fissure } from "../../../src/types/world.js";
 
 const NOW = Date.parse("2026-08-28T12:00:00.000Z");
@@ -73,5 +76,31 @@ describe("buildFissureRows in all mode", () => {
     ];
     expect(nodes(buildFissureRows(soon, "all", NOW, NOW))).toEqual(["Alive"]);
     expect(nodes(buildFissureRows(FISSURES, "all", NOW, NOW))).not.toContain("Meso Expired");
+  });
+});
+
+describe("fissureMissionTypeOptions", () => {
+  it("derives alert options from the active API fissures, including Railjack types", () => {
+    const fissures: Fissure[] = [
+      { missionType: "Void Flood" },
+      { missionType: "Alchemy" },
+      { missionType: "Assault" },
+      { missionType: "Infested Salvage" },
+      { missionType: "Skirmish", isStorm: true },
+      { missionType: "Orphix", isStorm: true },
+      { missionType: "Volatile", isStorm: true },
+      { missionType: "Void Flood" },
+      { missionType: "  " },
+    ];
+
+    expect(fissureMissionTypeOptions(fissures)).toEqual([
+      "Alchemy",
+      "Assault",
+      "Infested Salvage",
+      "Orphix",
+      "Skirmish",
+      "Void Flood",
+      "Volatile",
+    ]);
   });
 });


### PR DESCRIPTION
## What & why

- Derives fissure alert mission-type options from the active Warframe world state, including Railjack Void Storms, rather than a stale manual list.
- Resolves official English mission labels from the public export and normalizes their casing, including Void Flood, Infested Salvage, and Assault.
- Preserves the original English-only behavior for fissure labels across game locale changes.

Closes #30
Closes #31

## Checklist

- [x] `pnpm run check`, `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check` and `pnpm test` pass
- [x] Production build works (`pnpm run build`)
- [x] Follows the conventions in `CONTRIBUTING.md`
- [x] No telemetry or crash reporting added

## Verification note

The standalone Playwright suite has four pre-existing setup/layout failures unrelated to this change; the unit suite, backend suite, build, type checks, lint, formatting, ONNX validation, and Windows regressions pass.