### PR TITLE
[fix] - lowercase username before posting review to avoid 301 redirect

### DIFF
--- a/services/wfmReviews.ts
+++ b/services/wfmReviews.ts
@@ -10,7 +10,7 @@ export async function sendPlusRep(username: string): Promise<SendRepResult> {
   if (!name) return "failed";
 
   try {
-    await request("POST", `/profile/${encodeURIComponent(name)}/review`, {
+    await request("POST", `/profile/${encodeURIComponent(name.toLowerCase())}/review`, {
       json: { review_type: 1, text: "" },
     });
     log.info(`[Rep] +1 rep sent to ${name}`);

--- a/tests/main/wfmReviews.test.ts
+++ b/tests/main/wfmReviews.test.ts
@@ -19,7 +19,7 @@ describe("sendPlusRep", () => {
     requestMock.mockResolvedValueOnce({});
 
     await expect(sendPlusRep("PureFPSZac")).resolves.toBe("sent");
-    expect(requestMock).toHaveBeenCalledWith("POST", "/profile/PureFPSZac/review", {
+    expect(requestMock).toHaveBeenCalledWith("POST", "/profile/purefpszac/review", {
       json: { review_type: 1, text: "" },
     });
   });
@@ -28,7 +28,7 @@ describe("sendPlusRep", () => {
     requestMock.mockResolvedValueOnce({});
 
     await sendPlusRep("Some Name");
-    expect(requestMock).toHaveBeenCalledWith("POST", "/profile/Some%20Name/review", {
+    expect(requestMock).toHaveBeenCalledWith("POST", "/profile/some%20name/review", {
       json: { review_type: 1, text: "" },
     });
   });


### PR DESCRIPTION
## What & why

after trade, [F9] to leave review is failing because the username needs to be lowercase

## Checklist

- [✓] `pnpm run check`, `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check` and `pnpm test` pass
- [✓] Production build works (`pnpm run build`)
- [✓] Follows the conventions in `CONTRIBUTING.md`
- [✓] No telemetry or crash reporting added
